### PR TITLE
Refactoring

### DIFF
--- a/main.go
+++ b/main.go
@@ -24,14 +24,14 @@ import (
 )
 
 type (
-	// TrailCamSorter is a struct that represents a trail camera video file sorter.
-	TrailCamSorter struct {
-		Params    SorterParams    // Holds the command line flags.
-		IgnoreMap map[string]bool // Holds the list of files and directories to ignore.
+	// A struct that represents a trail camera video file sorter.
+	sorter struct {
+		params    sorterParams    // Holds the command line flags.
+		ignoreMap map[string]bool // Holds the list of files and directories to ignore.
 	}
 
-	// SorterParams contains parameters for the TrailCamSorter.
-	SorterParams struct {
+	// Contains parameters for the sorter.
+	sorterParams struct {
 		InputDir  string // The input directory containing video files.
 		OutputDir string // The output directory for sorted video files.
 		DryRun    bool   // If true, the files will not be moved.
@@ -40,15 +40,14 @@ type (
 		Workers   int    // The number of workers used to process files.
 	}
 
-	// TrailCamData a struct that contains the extracted data from a Trail Cam image.
-	TrailCamData struct {
+	// A struct that contains the extracted data from a Trail Cam image.
+	trailCamData struct {
 		Timestamp  time.Time // The timestamp of the observation (including both time and date).
 		CameraName string    // The name of the camera that captured the observation.
 	}
 
-	// BoundingBox represents a rectangular region in an image, identified by a label string and
-	// a corresponding image.Rectangle.
-	BoundingBox struct {
+	// A bBox represents a region in an image, identified by a label string and a corresponding image.Rectangle.
+	bBox struct {
 		Label string          // Label associated with this bounding box.
 		Rect  image.Rectangle // Rectangle specifying the region in the image.
 	}
@@ -59,13 +58,13 @@ var (
 	errMissingOutputDir     = errors.New("please specify output directory")
 	errLimitReached         = errors.New("limit reached")
 	errFailedToReadFrame    = errors.New("failed to read frame from video")
-	errJoinedImageIsEmpty   = errors.New("joined image is empty")
+	errLabeledImageIsEmpty  = errors.New("labeled image is empty")
 	errOCRReturnedEmptyText = errors.New("OCR returned empty text")
 	errInvalidTrailCamData  = errors.New("invalid TrailCamData")
 	errImageWrite           = errors.New("failed to write image to file")
 )
 
-// Entry point of the TrailCamSorter program.
+// Entry point of the program.
 // Creates a new instance.
 // Parses the command line arguments.
 // Processes the files.
@@ -84,39 +83,39 @@ func main() {
 		log.WithFields(log.Fields{"error": err}).Fatal("Error parsing flags")
 	}
 
-	// Create a new TrailCamSorter instance.
-	tcs := NewTrailCamSorter(params)
+	// Create a new sorter instance.
+	s := newSorter(params)
 
 	// Change logging level if debugging.
-	if tcs.Params.Debug {
+	if s.params.Debug {
 		log.SetLevel(log.DebugLevel)
 	}
 
 	// Process the files.
-	tcs.processFiles()
+	s.processFiles()
 
 	// Remove all empty directories in InputDir.
-	if err := tcs.removeEmptyDirs(); err != nil {
+	if err := s.removeEmptyDirs(); err != nil {
 		log.WithFields(log.Fields{"error": err}).Error("Error removing empty directories")
 	}
 
 	log.WithFields(log.Fields{"time_taken": time.Since(start)}).Info("Done.")
 }
 
-// NewTrailCamSorter initializes a new TrailCamSorter with the provided
-// SorterParams and the default IgnoreMap.
-// It returns a pointer to the newly created TrailCamSorter.
-func NewTrailCamSorter(params SorterParams) *TrailCamSorter {
-	return &TrailCamSorter{
-		Params:    params,         // Set the provided SorterParams to the new instance.
-		IgnoreMap: getIgnoreMap(), // Initialize the IgnoreMap with default values.
+// newSorter initializes a new sorter with the provided
+// sorterParams and the default IgnoreMap.
+// It returns a pointer to the newly created sorter.
+func newSorter(params sorterParams) *sorter {
+	return &sorter{
+		params:    params,         // Set the provided sorterParams to the new instance.
+		ignoreMap: getIgnoreMap(), // Initialize the ignoreMap with default values.
 	}
 }
 
-// Parses the command line flags and stores the results in the TrailCamSorter instance.
+// Parses the command line flags and stores the results in the sorter instance.
 // Returns an error if required flags are not set.
-func parseFlags() (SorterParams, error) {
-	var params SorterParams
+func parseFlags() (sorterParams, error) {
+	var params sorterParams
 
 	// Set command line flags.
 	flag.StringVar(&params.InputDir, "input", "", "the input directory containing video files")
@@ -170,15 +169,15 @@ func getIgnoreMap() map[string]bool {
 
 // Walks through the input directory and processes all video files by calling processFile on each file.
 // It returns an error if there is an error walking the input directory.
-func (tcs *TrailCamSorter) processFiles() {
+func (s *sorter) processFiles() {
 	const bufferSize = 100
 
 	filesChan := make(chan string, bufferSize)
 
 	var wg sync.WaitGroup
-	tcs.startWorkers(&wg, filesChan)
+	s.startWorkers(&wg, filesChan)
 
-	count, err := tcs.walkAndProcessFiles(filesChan)
+	count, err := s.walkAndProcessFiles(filesChan)
 
 	if err != nil && !errors.Is(err, errLimitReached) {
 		log.WithError(err).Info("Error occurred")
@@ -193,9 +192,9 @@ func (tcs *TrailCamSorter) processFiles() {
 // Creates and starts the specified number of worker goroutines
 // to process files concurrently. Each worker receives file paths from the
 // filesChan channel and processes them using the processFrame method.
-func (tcs *TrailCamSorter) startWorkers(wg *sync.WaitGroup, filesChan chan string) {
+func (s *sorter) startWorkers(wg *sync.WaitGroup, filesChan chan string) {
 	// Loop to create the specified number of worker goroutines.
-	for i := 0; i < tcs.Params.Workers; i++ {
+	for i := 0; i < s.params.Workers; i++ {
 		// Increment the WaitGroup counter.
 		wg.Add(1)
 
@@ -207,7 +206,7 @@ func (tcs *TrailCamSorter) startWorkers(wg *sync.WaitGroup, filesChan chan strin
 			// Process files sent to the filesChan channel.
 			for path := range filesChan {
 				// Process the file and log an error if it occurs.
-				if err := tcs.processFrame(path); err != nil {
+				if err := s.processFrame(path); err != nil {
 					log.WithFields(log.Fields{"path": path, "error": err}).Error("Error processing file")
 				}
 			}
@@ -218,25 +217,25 @@ func (tcs *TrailCamSorter) startWorkers(wg *sync.WaitGroup, filesChan chan strin
 // Walks the input directory, processes each file that
 // meets the criteria, and sends their paths to the filesChan channel.
 // It returns the total number of processed files and any error encountered.
-func (tcs *TrailCamSorter) walkAndProcessFiles(filesChan chan string) (int, error) {
+func (s *sorter) walkAndProcessFiles(filesChan chan string) (int, error) {
 	var count int
-	err := filepath.Walk(tcs.Params.InputDir, func(path string, info os.FileInfo, err error) error {
+	err := filepath.Walk(s.params.InputDir, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
-			return tcs.handleWalkError(path, err)
+			return s.handleWalkError(path, err)
 		}
 
 		if info.IsDir() {
-			return tcs.handleWalkDirectory(path)
+			return s.handleWalkDirectory(path)
 		}
 
-		return tcs.handleWalkFile(path, filesChan, &count)
+		return s.handleWalkFile(path, filesChan, &count)
 	})
 	return count, err
 }
 
 // Handles errors encountered while walking the input directory.
 // It logs the error and skips the directory if there's a permission issue.
-func (tcs *TrailCamSorter) handleWalkError(path string, err error) error {
+func (s *sorter) handleWalkError(path string, err error) error {
 	if os.IsPermission(err) {
 		log.WithFields(log.Fields{"path": path, "error": err}).Warn("Skipping directory due to permission issue")
 		return filepath.SkipDir
@@ -247,9 +246,9 @@ func (tcs *TrailCamSorter) handleWalkError(path string, err error) error {
 
 // Checks if a directory should be ignored while
 // walking the input directory, and skips it if necessary.
-func (tcs *TrailCamSorter) handleWalkDirectory(path string) error {
+func (s *sorter) handleWalkDirectory(path string) error {
 	dir := filepath.Base(path)
-	if tcs.IgnoreMap[dir] {
+	if s.ignoreMap[dir] {
 		log.WithFields(log.Fields{"type": "directory", "path": path}).Warn("Skipping ignored directory")
 		return filepath.SkipDir
 	}
@@ -259,18 +258,18 @@ func (tcs *TrailCamSorter) handleWalkDirectory(path string) error {
 // Processes a file encountered while walking the input directory.
 // It checks if the file should be ignored, has a video file extension, and if the limit is reached.
 // If the file passes these checks, it is added to the filesChan channel and the count is incremented.
-func (tcs *TrailCamSorter) handleWalkFile(path string, filesChan chan string, count *int) error {
+func (s *sorter) handleWalkFile(path string, filesChan chan string, count *int) error {
 	filename := filepath.Base(path)
-	if tcs.IgnoreMap[filename] {
+	if s.ignoreMap[filename] {
 		log.WithFields(log.Fields{"type": "file", "path": path}).Warn("Skipping ignored file")
 		return nil
 	}
 
-	if !tcs.hasVideoFileExtension(path) {
+	if !s.hasVideoFileExtension(path) {
 		return nil
 	}
 
-	if tcs.Params.Limit > 0 && *count >= tcs.Params.Limit {
+	if s.params.Limit > 0 && *count >= s.params.Limit {
 		return errLimitReached
 	}
 
@@ -280,35 +279,18 @@ func (tcs *TrailCamSorter) handleWalkFile(path string, filesChan chan string, co
 	return nil
 }
 
-// Creates an OpenCV Mat containing a blank image of the specified width and height,
-// and adds the specified label to the image.
-// The function returns the resulting image as an OpenCV Mat.
-func (tcs *TrailCamSorter) createLabelImage(label string, width int, height int) gocv.Mat {
-	blankImage := gocv.NewMatWithSizeFromScalar(gocv.NewScalar(0, 0, 0, 0), height, width, gocv.MatTypeCV8UC3)
-
-	// Add the box label to the blank image.
-	labelColor := color.RGBA{255, 255, 255, 0}
-	labelFontScale := 1.0
-	labelThickness := 1
-	labelStr := fmt.Sprintf("%s: ", label)
-	labelOrigin := image.Point{10, 30}
-	gocv.PutText(&blankImage, labelStr, labelOrigin, gocv.FontHersheySimplex, labelFontScale, labelColor, labelThickness)
-
-	return blankImage
-}
-
 // Processes the input video file to extract relevant TrailCamData. It attempts to
 // read multiple frames and uses OCR to extract the data. If the extraction is successful, the
 // function constructs an output path based on the extracted data and renames the input file
 // accordingly. If the extraction fails for all attempted frames, an error is returned.
-func (tcs *TrailCamSorter) processFrame(inputFile string) error {
-	var data TrailCamData
+func (s *sorter) processFrame(inputFile string) error {
+	var data trailCamData
 	var err error
 
 	// Attempt to read the frame.
 	frameNumber := 0
 	for frameNumber <= 10 {
-		data, err = tcs.processFrameWithNumber(inputFile, frameNumber)
+		data, err = s.processFrameWithNumber(inputFile, frameNumber)
 		if err != nil {
 			frameNumber++
 			continue
@@ -317,10 +299,10 @@ func (tcs *TrailCamSorter) processFrame(inputFile string) error {
 	}
 
 	// Construct an output path for the file.
-	outputPath := tcs.constructOutputPath(data)
+	outputPath := s.constructOutputPath(data)
 
 	// Rename the file.
-	if err := tcs.renameFile(inputFile, outputPath); err != nil {
+	if err := s.renameFile(inputFile, outputPath); err != nil {
 		return err
 	}
 
@@ -332,11 +314,11 @@ func (tcs *TrailCamSorter) processFrame(inputFile string) error {
 // the extraction process fails for the given frameNumber. The function is designed to be used
 // in a loop with increasing frame numbers until successful extraction or a predetermined limit
 // is reached.
-func (tcs *TrailCamSorter) processFrameWithNumber(inputFile string, frameNumber int) (TrailCamData, error) {
-	var data TrailCamData
+func (s *sorter) processFrameWithNumber(inputFile string, frameNumber int) (trailCamData, error) {
+	var data trailCamData
 
 	// Read a frame from the video file.
-	frame, err := tcs.readFrame(inputFile, frameNumber)
+	frame, err := s.readFrame(inputFile, frameNumber)
 	if frame == nil || err != nil {
 		log.WithFields(log.Fields{"error": err, "frame_num": frameNumber}).Error("Error frame is nil")
 		return data, err
@@ -350,40 +332,40 @@ func (tcs *TrailCamSorter) processFrameWithNumber(inputFile string, frameNumber 
 	}()
 
 	// Write frame to file for debugging.
-	err = tcs.debugImages(frame, fmt.Sprintf("%s-%d-%s.png", filepath.Base(inputFile), frameNumber, "frame"))
+	err = s.debugImages(frame, fmt.Sprintf("%s-%d-%s.png", filepath.Base(inputFile), frameNumber, "frame"))
 	if err != nil {
 		return data, err
 	}
 
 	// Create bounding boxes scaled to the width and height of the frame.
-	boundingBoxes := tcs.getBoundingBoxes(frame)
+	boundingBoxes := s.getBoundingBoxes(frame)
 
-	// Create the joined image.
-	joined, err := tcs.createJoinedImage(inputFile, frameNumber, boundingBoxes, frame)
+	// Create the labeled image.
+	labeled, err := s.createLabeledImage(inputFile, frameNumber, boundingBoxes, frame)
 	if err != nil {
-		log.WithFields(log.Fields{"error": err}).Error("Error creating joined image")
+		log.WithFields(log.Fields{"error": err}).Error("Error creating labeled image")
 		return data, err
 	}
 
-	// Close the joined file when the function completes (either normally or with an error).
+	// Close the labeled file when the function completes (either normally or with an error).
 	defer func() {
-		if err := joined.Close(); err != nil {
-			log.WithFields(log.Fields{"error": err, "frame_num": frameNumber}).Error("Error closing joined file")
+		if err := labeled.Close(); err != nil {
+			log.WithFields(log.Fields{"error": err, "frame_num": frameNumber}).Error("Error closing labeled file")
 		}
 	}()
 
-	// Perform OCR on the joined image.
-	text, err := tcs.performOCR(joined)
+	// Perform OCR on the labeled image.
+	text, err := s.performOCR(labeled)
 	if err != nil {
 		log.WithFields(log.Fields{"error": err, "ocr_text": text}).Error("Error performing OCR")
 		return data, err
 	}
 
-	// Update the TrailCamData object with the extracted data.
-	data = tcs.parseOCRText(data, text)
+	// Update the trailCamData object with the extracted data.
+	data = s.parseOCRText(data, text)
 
 	// Validate the TrailCamData.
-	err = tcs.validateTrailCamData(data)
+	err = s.validateTrailCamData(data)
 	if err != nil {
 		log.WithFields(log.Fields{"error": err, "frame_num": frameNumber}).Error("Error validating TrailCamData")
 		return data, err
@@ -397,7 +379,7 @@ func (tcs *TrailCamSorter) processFrameWithNumber(inputFile string, frameNumber 
 // Checks if the file extension is one of the supported video file extensions.
 // The path variable is the file path to be checked.
 // Returns true if the file has a supported video file extension, false otherwise.
-func (tcs *TrailCamSorter) hasVideoFileExtension(path string) bool {
+func (s *sorter) hasVideoFileExtension(path string) bool {
 	// Ignored filenames like: ._01.avi.
 	matchedInvalidAvi := regexp.MustCompile(`^\._.+\.avi$`).MatchString(filepath.Base(path))
 	if matchedInvalidAvi {
@@ -427,10 +409,10 @@ func (tcs *TrailCamSorter) hasVideoFileExtension(path string) bool {
 // The output path has the format: OutputDir/CameraName/Date/CameraName-Date-Time.avi
 // If a file already exists at the output path, a suffix is added to the file name.
 // Returns the constructed output path and an error, if any.
-func (tcs *TrailCamSorter) constructOutputPath(data TrailCamData) string {
+func (s *sorter) constructOutputPath(data trailCamData) string {
 	// Define the format for the output path.
 	outputPathFormat := filepath.Join(
-		tcs.Params.OutputDir,
+		s.params.OutputDir,
 		data.CameraName,
 		data.Timestamp.Format("2006-01-02"),
 		"%s-%s-%s.avi",
@@ -469,9 +451,9 @@ func (tcs *TrailCamSorter) constructOutputPath(data TrailCamData) string {
 // This function renames a file from the source path to the destination path.
 // If DryRun is true, it logs the operation without actually renaming the file.
 // It creates the destination directory if it doesn't exist, and returns an error if any of the operations fail.
-func (tcs *TrailCamSorter) renameFile(src string, dest string) error {
+func (s *sorter) renameFile(src string, dest string) error {
 	// Return early if DryRun is true.
-	if tcs.Params.DryRun {
+	if s.params.DryRun {
 		log.WithFields(log.Fields{"type": "DRY RUN", "src": src, "dest": dest}).Info("Skip renaming file")
 		return nil
 	}
@@ -494,7 +476,7 @@ func (tcs *TrailCamSorter) renameFile(src string, dest string) error {
 }
 
 // Reads a frame from a video file at the specified frame number and returns the frame data as a Mat object.
-func (tcs *TrailCamSorter) readFrame(inputFile string, frameNumber int) (*gocv.Mat, error) {
+func (s *sorter) readFrame(inputFile string, frameNumber int) (*gocv.Mat, error) {
 	// Open the video file.
 	cap, err := gocv.VideoCaptureFile(inputFile)
 	if err != nil {
@@ -533,7 +515,7 @@ func (tcs *TrailCamSorter) readFrame(inputFile string, frameNumber int) (*gocv.M
 // Calculates the pixel coordinates for each label defined in labelCoordinates
 // and returns a slice of bounding boxes. The bounding boxes are defined by their top-left
 // and bottom-right coordinates, relative to the input image dimensions provided as arguments.
-func (tcs *TrailCamSorter) getBoundingBoxes(imgMat *gocv.Mat) []BoundingBox {
+func (s *sorter) getBoundingBoxes(imgMat *gocv.Mat) []bBox {
 	// Define the label coordinates.
 	labelCoordinates := map[string][]float64{
 		"Timestamp":  {0.487240, 0.972685, 0.233854, 0.054630},
@@ -541,7 +523,7 @@ func (tcs *TrailCamSorter) getBoundingBoxes(imgMat *gocv.Mat) []BoundingBox {
 	}
 
 	// Create a slice to store the bounding boxes.
-	boundingBoxes := []BoundingBox{}
+	boundingBoxes := []bBox{}
 
 	// Loop through the label coordinates and create bounding boxes for each label.
 	for label, coords := range labelCoordinates {
@@ -558,7 +540,7 @@ func (tcs *TrailCamSorter) getBoundingBoxes(imgMat *gocv.Mat) []BoundingBox {
 		bottom := (y + h/2) * height
 
 		// Create the bounding box struct.
-		boundingBox := BoundingBox{
+		boundingBox := bBox{
 			Label: label,
 			Rect:  image.Rect(int(left), int(top), int(right), int(bottom)),
 		}
@@ -570,21 +552,38 @@ func (tcs *TrailCamSorter) getBoundingBoxes(imgMat *gocv.Mat) []BoundingBox {
 	return boundingBoxes
 }
 
+// Creates an OpenCV Mat containing a blank image of the specified width and height,
+// and adds the specified label to the image.
+// The function returns the resulting image as an OpenCV Mat.
+func (s *sorter) createLabelTemplate(label string, width int, height int) gocv.Mat {
+	blankImage := gocv.NewMatWithSizeFromScalar(gocv.NewScalar(0, 0, 0, 0), height, width, gocv.MatTypeCV8UC3)
+
+	// Add the box label to the blank image.
+	labelColor := color.RGBA{255, 255, 255, 0}
+	labelFontScale := 1.0
+	labelThickness := 1
+	labelStr := fmt.Sprintf("%s: ", label)
+	labelOrigin := image.Point{10, 30}
+	gocv.PutText(&blankImage, labelStr, labelOrigin, gocv.FontHersheySimplex, labelFontScale, labelColor, labelThickness)
+
+	return blankImage
+}
+
 // This function takes a video frame, a slice of bounding boxes, and a filepath, and returns a
 // concatenated image of the cropped bounding boxes and their labels. It first creates a container image
 // to hold the label and the cropped bounding box, overlays the cropped bounding box onto the label image,
-// concatenates the label image and the cropped bounding boxes, and writes the joined image to the specified filepath.
+// concatenates the label image and the cropped bounding boxes, and writes the labeled image to the specified filepath.
 // It returns an error if any of the image operations fail.
-func (tcs *TrailCamSorter) createJoinedImage(inputFile string, frameNumber int, boundingBoxes []BoundingBox, frame *gocv.Mat) (*gocv.Mat, error) { // nolint
-	// Initialize the joined variable with an empty image of the correct size.
-	joined := gocv.NewMatWithSize(0, 0, gocv.MatTypeCV8UC3)
+func (s *sorter) createLabeledImage(inputFile string, frameNum int, bBoxes []bBox, frame *gocv.Mat) (*gocv.Mat, error) {
+	// Initialize the labeled variable with an empty image of the correct size.
+	labeled := gocv.NewMatWithSize(0, 0, gocv.MatTypeCV8UC3)
 
-	// Initialize the labelImage variable with an empty image of the correct size.
-	labelImage := gocv.NewMatWithSize(0, 0, gocv.MatTypeCV8UC3)
+	// Initialize the labelTemplate variable with an empty image of the correct size.
+	labelTemplate := gocv.NewMatWithSize(0, 0, gocv.MatTypeCV8UC3)
 
 	// Loop through each bounding box and crop out the image.
 	var croppedImages []gocv.Mat
-	for _, box := range boundingBoxes {
+	for _, box := range bBoxes {
 		// Crop out the bounding box.
 		cropped := frame.Region(box.Rect)
 		defer func() {
@@ -596,68 +595,55 @@ func (tcs *TrailCamSorter) createJoinedImage(inputFile string, frameNumber int, 
 		// Create a blank container image to hold the label and the cropped bounding box.
 		const labelImageWidth = 800
 		const labelImageHeight = 60
-		labelImage = tcs.createLabelImage(box.Label, labelImageWidth, labelImageHeight)
+		labelTemplate = s.createLabelTemplate(box.Label, labelImageWidth, labelImageHeight)
 		defer func() {
-			if err := labelImage.Close(); err != nil {
+			if err := labelTemplate.Close(); err != nil {
 				log.WithField("error", err).Error("Error closing label image")
 			}
 		}()
 
 		// Overlay the cropped image onto the label image.
-		roi := labelImage.Region(image.Rectangle{
+		roi := labelTemplate.Region(image.Rectangle{
 			Min: image.Point{0, 0},
-			Max: image.Point{labelImage.Cols(), labelImage.Rows()},
+			Max: image.Point{labelTemplate.Cols(), labelTemplate.Rows()},
 		})
-		cropOrigin := image.Point{labelImage.Cols() - cropped.Cols(), 0}
+		cropOrigin := image.Point{labelTemplate.Cols() - cropped.Cols(), 0}
 		croppedRoi := roi.Region(image.Rectangle{
 			Min: cropOrigin,
 			Max: cropOrigin.Add(image.Point{cropped.Cols(), cropped.Rows()}),
 		})
 		cropped.CopyTo(&croppedRoi)
 
-		// Write cropped image to file for debugging.
-		err := tcs.debugImages(&cropped, fmt.Sprintf("%s-%d-%s.png", filepath.Base(inputFile), frameNumber, box.Label))
-		if err != nil {
-			continue
-		}
-
-		// Write label images to file for debugging.
-		labelImageName := fmt.Sprintf("%s-%d-%s.png", filepath.Base(inputFile), frameNumber, box.Label+"-label")
-		err = tcs.debugImages(&labelImage, labelImageName)
-		if err != nil {
-			continue
-		}
-
-		croppedImages = append(croppedImages, labelImage)
+		croppedImages = append(croppedImages, labelTemplate)
 	}
 
 	// Concatenate the cropped images.
 	for i := 0; i < len(croppedImages); i++ {
-		if joined.Empty() {
-			// If joined is empty, assign it to the first cropped image.
-			joined = croppedImages[i]
+		if labeled.Empty() {
+			// If labeled is empty, assign it to the first cropped image.
+			labeled = croppedImages[i]
 		} else {
-			// Otherwise, concatenate the cropped image to the bottom of joined.
-			gocv.Vconcat(joined, croppedImages[i], &joined)
+			// Otherwise, concatenate the cropped image to the bottom of labeled.
+			gocv.Vconcat(labeled, croppedImages[i], &labeled)
 		}
 	}
 
-	if joined.Empty() {
-		return nil, fmt.Errorf("%w", errJoinedImageIsEmpty)
+	if labeled.Empty() {
+		return nil, fmt.Errorf("%w", errLabeledImageIsEmpty)
 	}
 
-	// Write joined image to file for debugging.
-	err := tcs.debugImages(&joined, fmt.Sprintf("%s-%d-%s.png", filepath.Base(inputFile), frameNumber, "joined"))
+	// Write labeled image to file for debugging.
+	err := s.debugImages(&labeled, fmt.Sprintf("%s-%d-%s.png", filepath.Base(inputFile), frameNum, "labeled"))
 	if err != nil {
 		return nil, err
 	}
 
-	return &joined, nil
+	return &labeled, nil
 }
 
 // Performs OCR on a gocv.Mat object using Tesseract.
 // Returns the recognized text and any errors that occurred during the OCR process.
-func (tcs *TrailCamSorter) performOCR(imgMat *gocv.Mat) (string, error) {
+func (s *sorter) performOCR(imgMat *gocv.Mat) (string, error) {
 	// Create a new Tesseract client.
 	client := gosseract.NewClient()
 	defer func() {
@@ -715,7 +701,7 @@ func (tcs *TrailCamSorter) performOCR(imgMat *gocv.Mat) (string, error) {
 }
 
 // Parse OCR text and update TrailCamData object.
-func (tcs *TrailCamSorter) parseOCRText(data TrailCamData, ocrText string) TrailCamData {
+func (s *sorter) parseOCRText(data trailCamData, ocrText string) trailCamData {
 	const partsLength = 2
 
 	lines := strings.Split(ocrText, "\n")
@@ -724,7 +710,7 @@ func (tcs *TrailCamSorter) parseOCRText(data TrailCamData, ocrText string) Trail
 		if len(parts) == partsLength {
 			label := strings.TrimSpace(parts[0])
 			text := strings.TrimSpace(parts[1])
-			data = tcs.updateTrailCamData(data, label, text)
+			data = s.updateTrailCamData(data, label, text)
 		}
 	}
 	return data
@@ -733,7 +719,7 @@ func (tcs *TrailCamSorter) parseOCRText(data TrailCamData, ocrText string) Trail
 // Takes in a TrailCamData object and checks if its Timestamp field is not equal to zero,
 // and its CameraName field is not an empty string.
 // If either of these fields fails the validation, an error is returned.
-func (tcs *TrailCamSorter) validateTrailCamData(data TrailCamData) error {
+func (s *sorter) validateTrailCamData(data trailCamData) error {
 	var errs []string
 
 	// Check for valid Timestamp.
@@ -754,7 +740,7 @@ func (tcs *TrailCamSorter) validateTrailCamData(data TrailCamData) error {
 }
 
 // Updates a TrailCamData object with OCR results for a label.
-func (tcs *TrailCamSorter) updateTrailCamData(data TrailCamData, label string, text string) TrailCamData {
+func (s *sorter) updateTrailCamData(data trailCamData, label string, text string) trailCamData {
 	switch label {
 	case "Timestamp":
 		timestamp, err := time.Parse("03:04PM 01/02/2006", text)
@@ -779,15 +765,15 @@ func (tcs *TrailCamSorter) updateTrailCamData(data TrailCamData, label string, t
 }
 
 // Removes all empty directories that are subdirectories of the input directory.
-func (tcs *TrailCamSorter) removeEmptyDirs() error {
+func (s *sorter) removeEmptyDirs() error {
 	// Return early if DryRun is true.
-	if tcs.Params.DryRun {
+	if s.params.DryRun {
 		log.WithField("type", "DRY RUN").Info("Skip removing empty directories")
 		return nil
 	}
 
 	// Walk through the input directory and process each file.
-	err := filepath.Walk(tcs.Params.InputDir, func(path string, info os.FileInfo, err error) error {
+	err := filepath.Walk(s.params.InputDir, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			log.WithFields(log.Fields{"path": path, "error": err}).Error("Error accessing path")
 			return nil
@@ -798,7 +784,7 @@ func (tcs *TrailCamSorter) removeEmptyDirs() error {
 		}
 
 		// Check if the directory is a subdirectory of the InputDir.
-		if !strings.HasPrefix(path, tcs.Params.InputDir) {
+		if !strings.HasPrefix(path, s.params.InputDir) {
 			return filepath.SkipDir
 		}
 
@@ -825,8 +811,8 @@ func (tcs *TrailCamSorter) removeEmptyDirs() error {
 }
 
 // Write image to file for debugging.
-func (tcs *TrailCamSorter) debugImages(imgMat *gocv.Mat, filename string) error {
-	if !tcs.Params.Debug {
+func (s *sorter) debugImages(imgMat *gocv.Mat, filename string) error {
+	if !s.params.Debug {
 		return nil
 	}
 


### PR DESCRIPTION
- Lowercase the structs because none of them need to be exported.
- Renaming labeled image code for clarity.
- Renaming createJoinedImage to createLabeledImage.
- Removed unneeded calls to debugImages.